### PR TITLE
add a --cleanup function to dex

### DIFF
--- a/dex
+++ b/dex
@@ -56,4 +56,3 @@ fi
 
 # Run it using docker instead of docker-compose as it is much faster to bootstrap
 docker exec -it $COMPOSE_CONTAINER_NAME $@
-

--- a/dex
+++ b/dex
@@ -1,50 +1,56 @@
 #!/bin/bash
+SERVICE_NAME=$(cat .docker-compose-default-service | tr -d '[:space:]')
 
 if [ "$1" = "--stop" ]; then
 	docker-compose stop
 	docker-sync stop
 	exit 0
-fi
-
-SERVICE_NAME=$(cat .docker-compose-default-service | tr -d '[:space:]')
-if [ -z "$SERVICE_NAME" ]; then
-	echo "Configure default service name:"
-	echo "echo service-name > .docker-compose-default-service"
-	exit
-fi
-
-# Lets assume the default project name derivated from dir name
-COMPOSE_CONTAINER_NAME=$(basename $(pwd) | tr -d '[\-_]')_${SERVICE_NAME}_1
-
-# CHECK DOCKER-SYNC RUNNING
-DOCKER_SYNC_PID=$(cat .docker-sync/daemon.pid 2> /dev/null)
-if ( [ -z "$DOCKER_SYNC_PID" ] || ! kill -0 $DOCKER_SYNC_PID ); then
-	echo "Docker-sync is not running."
-	echo "Starting 'docker-sync' in background..."
-	DOCKER_SYNC_VERSION=$(docker-sync -v)
-
-	if ! ( echo $DOCKER_SYNC_VERSION | grep '^0\.[234]' > /dev/null ); then
-		echo "ERROR: Docker-sync version $DOCKER_SYNC_VERSION is not supported! Please install docker-sync 0.2.*."
-		exit 1
+elif [ "$1" = "--cleanup" ]; then
+  docker-compose stop
+  docker-sync stop
+  docker-compose rm $SERVICE_NAME -f
+  docker-sync clean
+  exit 0
+else
+	if [ -z "$SERVICE_NAME" ]; then
+		echo "Configure default service name:"
+		echo "echo service-name > .docker-compose-default-service"
+		exit
 	fi
-	docker-sync start
-fi
 
-# CHECK DOCKER CONTAINER RUNNNING
-CONTAINER_RUNS_TEST=$(docker ps -q -f name=$COMPOSE_CONTAINER_NAME)
-if [ -z "$CONTAINER_RUNS_TEST" ]; then
-	echo "Container $COMPOSE_CONTAINER_NAME not running... Starting 'docker-compose up' in background"
+	# Lets assume the default project name derivated from dir name
+	COMPOSE_CONTAINER_NAME=$(basename $(pwd) | tr -d '[\-_]')_${SERVICE_NAME}_1
 
-	# start docker-compose if it is not running
-	if [ -f docker-compose.override.yml ]; then
-		docker-compose -f docker-compose.yml -f docker-compose.override.yml up -d
-	elif [ -f docker-compose.sync.yml ]; then
-		docker-compose -f docker-compose.yml -f docker-compose.sync.yml up -d
-	else
-		echo "WARNING: Starting docker-compose with default docker-compose.yml file"
-		docker-compose up -d
+	# CHECK DOCKER-SYNC RUNNING
+	DOCKER_SYNC_PID=$(cat .docker-sync/daemon.pid 2> /dev/null)
+	if ( [ -z "$DOCKER_SYNC_PID" ] || ! kill -0 $DOCKER_SYNC_PID ); then
+		echo "Docker-sync is not running."
+		echo "Starting 'docker-sync' in background..."
+		DOCKER_SYNC_VERSION=$(docker-sync -v)
+
+		if ! ( echo $DOCKER_SYNC_VERSION | grep '^0\.[234]' > /dev/null ); then
+			echo "ERROR: Docker-sync version $DOCKER_SYNC_VERSION is not supported! Please install docker-sync 0.2.*."
+			exit 1
+		fi
+		docker-sync start
 	fi
-fi
 
-# Run it using docker instead of docker-compose as it is much faster to bootstrap
-docker exec -it $COMPOSE_CONTAINER_NAME $@
+	# CHECK DOCKER CONTAINER RUNNNING
+	CONTAINER_RUNS_TEST=$(docker ps -q -f name=$COMPOSE_CONTAINER_NAME)
+	if [ -z "$CONTAINER_RUNS_TEST" ]; then
+		echo "Container $COMPOSE_CONTAINER_NAME not running... Starting 'docker-compose up' in background"
+
+		# start docker-compose if it is not running
+		if [ -f docker-compose.override.yml ]; then
+			docker-compose -f docker-compose.yml -f docker-compose.override.yml up -d
+		elif [ -f docker-compose.sync.yml ]; then
+			docker-compose -f docker-compose.yml -f docker-compose.sync.yml up -d
+		else
+			echo "WARNING: Starting docker-compose with default docker-compose.yml file"
+			docker-compose up -d
+		fi
+	fi
+
+	# Run it using docker instead of docker-compose as it is much faster to bootstrap
+	docker exec -it $COMPOSE_CONTAINER_NAME $@
+fi

--- a/dex
+++ b/dex
@@ -1,56 +1,59 @@
 #!/bin/bash
 SERVICE_NAME=$(cat .docker-compose-default-service | tr -d '[:space:]')
 
+if [ -z "$SERVICE_NAME" ]; then
+	echo "Configure default service name:"
+	echo "echo service-name > .docker-compose-default-service"
+	exit
+fi
+
 if [ "$1" = "--stop" ]; then
 	docker-compose stop
 	docker-sync stop
 	exit 0
-elif [ "$1" = "--cleanup" ]; then
-  docker-compose stop
-  docker-sync stop
-  docker-compose rm $SERVICE_NAME -f
-  docker-sync clean
-  exit 0
-else
-	if [ -z "$SERVICE_NAME" ]; then
-		echo "Configure default service name:"
-		echo "echo service-name > .docker-compose-default-service"
-		exit
-	fi
-
-	# Lets assume the default project name derivated from dir name
-	COMPOSE_CONTAINER_NAME=$(basename $(pwd) | tr -d '[\-_]')_${SERVICE_NAME}_1
-
-	# CHECK DOCKER-SYNC RUNNING
-	DOCKER_SYNC_PID=$(cat .docker-sync/daemon.pid 2> /dev/null)
-	if ( [ -z "$DOCKER_SYNC_PID" ] || ! kill -0 $DOCKER_SYNC_PID ); then
-		echo "Docker-sync is not running."
-		echo "Starting 'docker-sync' in background..."
-		DOCKER_SYNC_VERSION=$(docker-sync -v)
-
-		if ! ( echo $DOCKER_SYNC_VERSION | grep '^0\.[234]' > /dev/null ); then
-			echo "ERROR: Docker-sync version $DOCKER_SYNC_VERSION is not supported! Please install docker-sync 0.2.*."
-			exit 1
-		fi
-		docker-sync start
-	fi
-
-	# CHECK DOCKER CONTAINER RUNNNING
-	CONTAINER_RUNS_TEST=$(docker ps -q -f name=$COMPOSE_CONTAINER_NAME)
-	if [ -z "$CONTAINER_RUNS_TEST" ]; then
-		echo "Container $COMPOSE_CONTAINER_NAME not running... Starting 'docker-compose up' in background"
-
-		# start docker-compose if it is not running
-		if [ -f docker-compose.override.yml ]; then
-			docker-compose -f docker-compose.yml -f docker-compose.override.yml up -d
-		elif [ -f docker-compose.sync.yml ]; then
-			docker-compose -f docker-compose.yml -f docker-compose.sync.yml up -d
-		else
-			echo "WARNING: Starting docker-compose with default docker-compose.yml file"
-			docker-compose up -d
-		fi
-	fi
-
-	# Run it using docker instead of docker-compose as it is much faster to bootstrap
-	docker exec -it $COMPOSE_CONTAINER_NAME $@
 fi
+
+if [ "$1" = "--cleanup" ]; then
+	docker-compose stop
+	docker-sync stop
+	docker-compose rm $SERVICE_NAME -f
+	docker-sync clean
+	exit 0
+fi
+
+# Lets assume the default project name derivated from dir name
+COMPOSE_CONTAINER_NAME=$(basename $(pwd) | tr -d '[\-_]')_${SERVICE_NAME}_1
+
+# CHECK DOCKER-SYNC RUNNING
+DOCKER_SYNC_PID=$(cat .docker-sync/daemon.pid 2> /dev/null)
+if ( [ -z "$DOCKER_SYNC_PID" ] || ! kill -0 $DOCKER_SYNC_PID ); then
+	echo "Docker-sync is not running."
+	echo "Starting 'docker-sync' in background..."
+	DOCKER_SYNC_VERSION=$(docker-sync -v)
+
+	if ! ( echo $DOCKER_SYNC_VERSION | grep '^0\.[234]' > /dev/null ); then
+		echo "ERROR: Docker-sync version $DOCKER_SYNC_VERSION is not supported! Please install docker-sync 0.2.*."
+		exit 1
+	fi
+	docker-sync start
+fi
+
+# CHECK DOCKER CONTAINER RUNNNING
+CONTAINER_RUNS_TEST=$(docker ps -q -f name=$COMPOSE_CONTAINER_NAME)
+if [ -z "$CONTAINER_RUNS_TEST" ]; then
+	echo "Container $COMPOSE_CONTAINER_NAME not running... Starting 'docker-compose up' in background"
+
+	# start docker-compose if it is not running
+	if [ -f docker-compose.override.yml ]; then
+		docker-compose -f docker-compose.yml -f docker-compose.override.yml up -d
+	elif [ -f docker-compose.sync.yml ]; then
+		docker-compose -f docker-compose.yml -f docker-compose.sync.yml up -d
+	else
+		echo "WARNING: Starting docker-compose with default docker-compose.yml file"
+		docker-compose up -d
+	fi
+fi
+
+# Run it using docker instead of docker-compose as it is much faster to bootstrap
+docker exec -it $COMPOSE_CONTAINER_NAME $@
+


### PR DESCRIPTION
As discussed the other day, we are all facing the occasional memory issue due to running containers etc.

I though the process i use to clean up each time might be of use.

Using the same behaviour as `--stop` i've added the removal of the app container (not the database etc) and  `docker-sync clean`

With this you preserve the dependancies, but are able to wipe out everything else which takes up diskspace.

I'm not 100% if this is pretty bash, but it works®